### PR TITLE
Add basic utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "contributors:add": "all-contributors add",
     "contributors:generate": "all-contributors generate",
-    "start": "node index.mjs"
+    "start": "node index.mjs",
+    "test": "node tests/utils.test.mjs"
   },
   "devDependencies": {
     "all-contributors-cli": "^6.26.1",

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+import { kebab, camelCase, cleanFilename, mergeDeep } from '../utils.mjs';
+
+assert.strictEqual(kebab('Hello World'), 'hello-world');
+assert.strictEqual(camelCase('hello world'), 'helloWorld');
+assert.strictEqual(cleanFilename('  My File! '), 'my_file');
+assert.deepStrictEqual(mergeDeep({a:1}, {b:2}), {a:1, b:2});
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add basic tests for utils
- enable `npm test` script using node

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6846c9d3dc68832e9a3ba225e1cd60b9